### PR TITLE
tiny fix to export bandwidth()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.Rproj
 .Rproj.user
 .Rhistory
 .RData

--- a/R/toxic.R
+++ b/R/toxic.R
@@ -12,7 +12,7 @@ latency <- function(latency=0, jitter=0) {
 ##' Limit a connection to a maximum number of kilobytes per second.
 ##' @title Bandwidth toxic
 ##' @param rate rate in KB/s
-##' '@export
+##' @export
 bandwidth <- function(rate=0) {
   toxic("bandwidth", list(rate=rate))
 }

--- a/man/bandwidth.Rd
+++ b/man/bandwidth.Rd
@@ -7,8 +7,7 @@
 bandwidth(rate = 0)
 }
 \arguments{
-\item{rate}{rate in KB/s
-'}
+\item{rate}{rate in KB/s}
 }
 \description{
 Limit a connection to a maximum number of kilobytes per second.


### PR DESCRIPTION
the `@export` tag wasn't being recognized cause a `'` in front of it
